### PR TITLE
Writing successful transactions and clearing old withdrawals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ keys.txt
 keys.json
 failedTransactions.csv
 withdrawals.csv
+successfulTransactions.csv

--- a/README.md
+++ b/README.md
@@ -34,7 +34,10 @@
 3. Execute the command "node index.js"
 4. Allow the script to run, do not let the machine go to sleep until all transactions have been submitted
 
-Please note that only 1 withdrawal can be run at once, that means you need to get approval for a withdrawal before the next one can be kicked off. This is a limitation with our APIs and for now cannot be worked around.
+<h3>Things to Note</h3>
+- Successful transactions will be written to a file called successfulTransactions.csv and failed ones go to fialedTransactions.csv
+- Only 1 withdrawal can be run at once, that means you need to get approval for a withdrawal before the next one can be kicked off. This is a limitation with our APIs and for now cannot be worked around
+- After running the tool, withdrawals.csv will be cleared of all content to prevent accidental re-running of the same transactions
 
 <h3>Error Handling</h3>
 


### PR DESCRIPTION
The idea here is that we want to also record all the successful transactions in another CSV and then actually clean out withdrawals.csv. 
I wanted to do this because to prevent them from re-running the same transactions again, if they want to run them again they need to deliberately paste them back into the file.